### PR TITLE
Mariana/combine maf files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,4 +87,5 @@ logging_kenneth-ml.conf
 logging_jkchang.conf
 logging_C02R51F3FVH8.conf
 logging_C02RN2JFFVH8.conf
+logging_JF3F6YXL4V.conf
 venv382

--- a/app/ws/misc_utilities/dataframe_utils.py
+++ b/app/ws/misc_utilities/dataframe_utils.py
@@ -7,7 +7,7 @@ logger = logging.getLogger('builder')
 class DataFrameUtils:
 
     @staticmethod
-    def NMR_assay_cleanup(df: pandas.DataFrame):
+    def NMR_assay_cleanup(df: pandas.DataFrame) -> pandas.DataFrame:
         '''
         Change / mapping NMR Study dataframe column name
         :param df: NMR Dataframe to cleanup
@@ -45,7 +45,7 @@ class DataFrameUtils:
         return df
 
     @staticmethod
-    def LCMS_assay_cleanup(df: pandas.DataFrame):
+    def LCMS_assay_cleanup(df: pandas.DataFrame) -> pandas.DataFrame:
         '''
         Change / mapping LCMS Study dataframe column name
         :param df: LC** DataFrame to cleanup
@@ -97,11 +97,11 @@ class DataFrameUtils:
 
 
     @staticmethod
-    def sample_cleanup(df):
+    def sample_cleanup(df) -> pandas.DataFrame:
         '''
         Change / mapping sample file dataframe column name
-        :param df:
-        :return:
+        :param df: Sample file to cleanup
+        :return: Dataframe with with renamed columns and unwanted columns removed
         '''
         keep = ['Study', 'Characteristics[Organism]', 'Characteristics[Organism part]', 'Protocol REF', 'Sample Name']
         rename = {'Characteristics[Organism]': 'Characteristics.Organism.',
@@ -116,7 +116,7 @@ class DataFrameUtils:
         return df
 
     @staticmethod
-    def LCMS_maf_cleanup(df: pandas.DataFrame):
+    def LCMS_maf_cleanup(df: pandas.DataFrame, study_id: str, maf_filename: str) -> pandas.DataFrame:
         """
         Remove any columns we don't want from the LCMS maf file, and rename the others so as to make them more receptive
         to being computed.
@@ -129,18 +129,22 @@ class DataFrameUtils:
                 'database_version', 'reliability', 'uri', 'search_engine', 'search_engine_score',
                 'smallmolecule_abundance_sub', 'smallmolecule_abundance_stdev_sub',
                 'smallmolecule_abundance_std_error_sub']
-        k = pandas.DataFrame(colums=keep)
+        k = pandas.DataFrame(columns=keep)
         k = k.append(df, sort=False)
         df = k[keep]
+        df.insert(0, 'maf_filename', maf_filename)
+        df.insert(0, 'study_id', study_id)
         return df
 
     @staticmethod
-    def NMR_maf_cleanup(df: pandas.DataFrame):
+    def NMR_maf_cleanup(df: pandas.DataFrame, study_id: str, maf_filename: str) -> pandas.DataFrame:
         """
         Remove any columns we don't want from the LCMS maf file, and rename the others so as to make them more receptive
         to being computed.
 
         :param df: NMR maf file to clean up.
+        :param study_id: The accession number of the study that the maf belongs to.
+        :param maf_filename: Maf filename to save as a new column in the dataframe.
         :return: Dataframe with renamed columns and unwanted columns removed.
         """
         logger.info('hit NMR MAF cleanup')
@@ -152,6 +156,8 @@ class DataFrameUtils:
         try:
             k = k.append(df, sort=False)
             df = k[keep]
+            df.insert(0, 'maf_filename', maf_filename)
+            df.insert(0, 'study_id', study_id)
         except Exception as e:
             logger.error(f'unexpected issue with cleaning up dataframe: {str(e)}')
         return df

--- a/app/ws/misc_utilities/dataframe_utils.py
+++ b/app/ws/misc_utilities/dataframe_utils.py
@@ -148,7 +148,7 @@ class DataFrameUtils:
                 'chemical_shift', 'multiplicity', 'taxid', 'species', 'database', 'database_version',
                 'reliability','uri', 'search_engine', 'search_engine_score', 'smallmolecule_abundance_sub',
                 'smallmolecule_abundance_stdev_sub']
-        k = pandas.DataFrame(colums=keep)
+        k = pandas.DataFrame(columns=keep)
         try:
             k = k.append(df, sort=False)
             df = k[keep]

--- a/app/ws/misc_utilities/dataframe_utils.py
+++ b/app/ws/misc_utilities/dataframe_utils.py
@@ -112,3 +112,39 @@ class DataFrameUtils:
         df = df.rename(columns=rename)
         return df
 
+    @staticmethod
+    def LCMS_maf_cleanup(df: pandas.DataFrame):
+        """
+        Remove any columns we don't want from the LCMS maf file, and rename the others so as to make them more receptive
+        to being computed.
+
+        :param df: LCMS maf file to clean up.
+        :return: Dataframe with renamed columns and unwanted columns removed.
+        """
+        keep = ['database_identifier', 'chemical_formula', 'inchi', 'metabolite_identification', 'mass_to_charge',
+                'fragmentation', 'modification', 'charge', 'retention_time', 'taxid', 'species', 'database',
+                'database_version', 'reliability', 'uri', 'search_engine', 'search_engine_score',
+                'smallmolecule_abundance_sub', 'smallmolecule_abundance_stdev_sub',
+                'smallmolecule_abundance_std_error_sub']
+        k = pandas.DataFrame(colums=keep)
+        k = k.append(df, sort=False)
+        df = k[keep]
+        return df
+
+    @staticmethod
+    def NMR_maf_cleanup(df: pandas.DataFrame):
+        """
+        Remove any columns we don't want from the LCMS maf file, and rename the others so as to make them more receptive
+        to being computed.
+
+        :param df: NMR maf file to clean up.
+        :return: Dataframe with renamed columns and unwanted columns removed.
+        """
+        keep = ['database_identifier', 'chemical_formula', 'smiles', 'inchi', 'metabolite_identification',
+                'chemical_shift', 'multiplicity', 'taxid', 'species', 'database', 'database_version',
+                'reliability','uri', 'search_engine', 'search_engine_score', 'smallmolecule_abundance_sub',
+                'smallmolecule_abundance_stdev_sub']
+        k = pandas.DataFrame(colums=keep)
+        k = k.append(df, sort=False)
+        df = k[keep]
+        return df

--- a/app/ws/misc_utilities/dataframe_utils.py
+++ b/app/ws/misc_utilities/dataframe_utils.py
@@ -1,4 +1,7 @@
+import logging
 import pandas
+
+logger = logging.getLogger('builder')
 
 
 class DataFrameUtils:
@@ -140,11 +143,15 @@ class DataFrameUtils:
         :param df: NMR maf file to clean up.
         :return: Dataframe with renamed columns and unwanted columns removed.
         """
+        logger.info('hit NMR MAF cleanup')
         keep = ['database_identifier', 'chemical_formula', 'smiles', 'inchi', 'metabolite_identification',
                 'chemical_shift', 'multiplicity', 'taxid', 'species', 'database', 'database_version',
                 'reliability','uri', 'search_engine', 'search_engine_score', 'smallmolecule_abundance_sub',
                 'smallmolecule_abundance_stdev_sub']
         k = pandas.DataFrame(colums=keep)
-        k = k.append(df, sort=False)
-        df = k[keep]
+        try:
+            k = k.append(df, sort=False)
+            df = k[keep]
+        except Exception as e:
+            logger.error(f'unexpected issue with cleaning up dataframe: {str(e)}')
         return df

--- a/app/ws/mtbls_maf.py
+++ b/app/ws/mtbls_maf.py
@@ -318,9 +318,12 @@ class CombineMetaboliteAnnotationFiles(Resource):
         combiBuilder.build()
 
         return {
-            'status': f'Combined Maf File Built, with {len(combiBuilder.missed_maf_register)} MAFs unable to be opened:  '
-                      f'{str(combiBuilder.missed_maf_register)}. There were '
-                      f'{len(combiBuilder.no_relevant_maf_register)} studies that had MAF files, but no MAF file '
-                      f'matching the given analytical method {method}: {str(combiBuilder.no_relevant_maf_register)}'
+            'status': f'Combined Maf File Built, with {len(combiBuilder.unopenable_maf_register)} MAFs unable to be '
+                      f'opened: {str(combiBuilder.unopenable_maf_register)}. There were '
+                      f'{len(combiBuilder.missing_maf_register)} studies that had no MAF files: '
+                      f'{str(combiBuilder.missing_maf_register)} .There were '
+                      f'{len(combiBuilder.no_relevant_maf_register)} studies that had MAF files, but no '
+                      f'MAF file matching the given analytical method {method}: '
+                      f'{str(combiBuilder.no_relevant_maf_register)}'
         }
 

--- a/app/ws/mtbls_maf.py
+++ b/app/ws/mtbls_maf.py
@@ -236,7 +236,63 @@ class MetaboliteAnnotationFile(Resource):
         return {"success": "Added/Updated MAF(s)" + maf_feedback}
 
 class CombineMetaboliteAnnotationFiles(Resource):
-
+    @swagger.operation(
+        summary="Combine MAFs for a list of studies",
+        nickname="Combine MAF files",
+        notes='''Combine MAF files for a given list of studies, by analytical method. If a study contains assays with 
+        more than one analytical method, it will endeavour to try and select only the MAFs that correspond to the chosen 
+        analytical method.
+    <pre><code> 
+    {  
+      "data": [ 
+        "MTBLS1",
+        "MTBLS2",
+        "MTBLS3",
+      ],
+      method: "NMR"
+    }
+    </code></pre>''',
+        parameters=[
+            {
+                "name": "data",
+                "description": "Studies to combine MAFs for, and the analytical method",
+                "required": True,
+                "allowMultiple": False,
+                "paramType": "body",
+                "dataType": "string"
+            },
+            {
+                "name": "user_token",
+                "description": "User API token",
+                "paramType": "header",
+                "type": "string",
+                "required": True,
+                "allowMultiple": False
+            }
+        ],
+        responseMessages=[
+            {
+                "code": 200,
+                "message": "OK. The Metabolite Annotation File (MAF) is returned"
+            },
+            {
+                "code": 401,
+                "message": "Unauthorized. Access to the resource requires user authentication."
+            },
+            {
+                "code": 403,
+                "message": "Forbidden. Access to the study is not allowed for this user."
+            },
+            {
+                "code": 404,
+                "message": "Not found. The requested identifier is not valid or does not exist."
+            },
+            {
+                "code": 417,
+                "message": "Incorrect parameters provided"
+            }
+        ]
+    )
     def post(self):
         data_dict = json.loads(request.data.decode('utf-8'))
         studies_to_combine = data_dict['data']

--- a/app/ws/mtbls_maf.py
+++ b/app/ws/mtbls_maf.py
@@ -318,9 +318,9 @@ class CombineMetaboliteAnnotationFiles(Resource):
         combiBuilder.build()
 
         return {
-            'status': f'Combined Maf File Built, with {len(combiBuilder.missed_maf_register)} missing MAFs:  '
+            'status': f'Combined Maf File Built, with {len(combiBuilder.missed_maf_register)} MAFs unable to be opened:  '
                       f'{str(combiBuilder.missed_maf_register)}. There were '
-                      f'{len(combiBuilder.no_relevant_maf_register)} studies that had no MAF file matching the '
-                      f'given analytical method {method}: {str(combiBuilder.no_relevant_maf_register)}'
+                      f'{len(combiBuilder.no_relevant_maf_register)} studies that had MAF files, but no MAF file '
+                      f'matching the given analytical method {method}: {str(combiBuilder.no_relevant_maf_register)}'
         }
 

--- a/app/ws/mtbls_maf.py
+++ b/app/ws/mtbls_maf.py
@@ -296,7 +296,7 @@ class CombineMetaboliteAnnotationFiles(Resource):
     def post(self):
         data_dict = json.loads(request.data.decode('utf-8'))
         studies_to_combine = data_dict['data']
-        method = data_dict['analytical_method']
+        method = data_dict['method']
 
         if studies_to_combine is None:
             abort(417)

--- a/app/ws/mtbls_maf.py
+++ b/app/ws/mtbls_maf.py
@@ -318,7 +318,9 @@ class CombineMetaboliteAnnotationFiles(Resource):
         combiBuilder.build()
 
         return {
-            'status': f'Combined Maf File Built, with {combiBuilder.missed_maf_register.__len__()} missing MAFs:  '
-                      f'{combiBuilder.missed_maf_register.__str__()}'
+            'status': f'Combined Maf File Built, with {len(combiBuilder.missed_maf_register)} missing MAFs:  '
+                      f'{str(combiBuilder.missed_maf_register)}. There were '
+                      f'{len(combiBuilder.no_relevant_maf_register)} studies that had no MAF file matching the '
+                      f'given analytical method {method}: {str(combiBuilder.no_relevant_maf_register)}'
         }
 

--- a/app/ws/mtbls_maf.py
+++ b/app/ws/mtbls_maf.py
@@ -316,8 +316,7 @@ class CombineMetaboliteAnnotationFiles(Resource):
         )
 
         combiBuilder.build()
-
-        return {
+        r_d = {
             'status': f'Combined Maf File Built, with {len(combiBuilder.unopenable_maf_register)} MAFs unable to be '
                       f'opened: {str(combiBuilder.unopenable_maf_register)}. There were '
                       f'{len(combiBuilder.missing_maf_register)} studies that had no MAF files: '
@@ -326,4 +325,6 @@ class CombineMetaboliteAnnotationFiles(Resource):
                       f'MAF file matching the given analytical method {method}: '
                       f'{str(combiBuilder.no_relevant_maf_register)}'
         }
-
+        # logging it out in the event of the swagger UI crashing as these are useful numbers
+        logger.info(r_d['status'])
+        return r_d

--- a/app/ws/report_builders/combined_maf_builder.py
+++ b/app/ws/report_builders/combined_maf_builder.py
@@ -124,7 +124,7 @@ class CombinedMafBuilder:
         finally:
             if maf_file_list is None:
                 self.missing_study_directory_register.append(study_location)
-            if len(maf_file_list) is 0:
+            elif len(maf_file_list) is 0:
                 self.missing_maf_register.append(study_id)
                 return maf_file_list
 

--- a/app/ws/report_builders/combined_maf_builder.py
+++ b/app/ws/report_builders/combined_maf_builder.py
@@ -67,10 +67,10 @@ class CombinedMafBuilder:
         """
         for i, study_id in enumerate(self.studies_to_combine):
             logger.info(f'hit get dataframes first loop {str(i)} times')
-            copy = repr(self.original_study_location)
+            copy = repr(self.original_study_location).strip("'")
             study_location = copy.replace("MTBLS1", study_id)
             for maf in self.sort_mafs(study_location):
-                logger.error(f'{maf}')
+                logger.error(f' hit get dataframes interior loop with {maf}')
                 maf_temp = None
                 try:
                     maf_temp = pandas.read_csv(os.path.join(study_location, maf), sep="\t", header=0, encoding='unicode_escape')
@@ -83,7 +83,9 @@ class CombinedMafBuilder:
                     self.missed_maf_register.append(maf)
                     continue
                 cleanup_function = getattr(DataFrameUtils, f'{self.method}_maf_cleanup')
+                logger.info(cleanup_function)
                 maf_temp = cleanup_function(maf_temp)
+                logger.info(f'maf file post cleanup: {maf_temp}')
                 maf_as_dict = totuples(df=maf_temp, text='dict')['dict']
                 yield maf_as_dict
 
@@ -97,6 +99,7 @@ class CombinedMafBuilder:
         :param study_location: The location in the filesystem of the study, as a string.
         :return: A List of strings representing culled filenames.
         """
+        #study_location = study_location.strip("'")
         logger.error(f'hit sorts maf for {study_location}, method: {self.method}')
         filtered_maf_list = []
         tokens = {
@@ -105,10 +108,11 @@ class CombinedMafBuilder:
         }
         maf_file_list = None
         logger.info(f'current directory: {os.getcwd()}')
-        os.chdir(study_location)
+        # os.chdir(study_location)
         try:
-            maf_file_list = [file for file in os.listdir() if
-                             file.startswith('m_') and file.endswith('.txt')]
+            logger.info(str([file for file in os.listdir(study_location)]))
+            maf_file_list = [file for file in os.listdir(study_location) if
+                             file.startswith('m_') and file.endswith('.tsv')]
         except FileNotFoundError as e:
             logger.error(f'FileNotFoundError: {str(e)}')
         except NotADirectoryError as e:

--- a/app/ws/report_builders/combined_maf_builder.py
+++ b/app/ws/report_builders/combined_maf_builder.py
@@ -82,11 +82,13 @@ class CombinedMafBuilder:
                     logger.error(f'Issue with opening maf file {maf}, cause of error unclear: {str(e)}')
                     self.missed_maf_register.append(maf)
                     continue
+
                 cleanup_function = getattr(DataFrameUtils, f'{self.method}_maf_cleanup')
                 logger.info(cleanup_function)
-                maf_temp = cleanup_function(maf_temp)
+                maf_temp = cleanup_function(maf_temp, study_id, maf)
                 logger.info(f'maf file post cleanup: {maf_temp}')
                 maf_as_dict = totuples(df=maf_temp, text='dict')['dict']
+
                 yield maf_as_dict
 
             # assuming that a maf has been found as they have been hand selected

--- a/app/ws/report_builders/combined_maf_builder.py
+++ b/app/ws/report_builders/combined_maf_builder.py
@@ -16,6 +16,7 @@ class CombinedMafBuilder:
     """
 
     def __init__(self, studies_to_combine: List[str], original_study_location: str, method: str):
+        logger.error('error')
         self.studies_to_combine = studies_to_combine
         self.original_study_location = original_study_location
         self.method = method

--- a/app/ws/report_builders/combined_maf_builder.py
+++ b/app/ws/report_builders/combined_maf_builder.py
@@ -124,6 +124,7 @@ class CombinedMafBuilder:
         finally:
             if maf_file_list is None:
                 self.missing_study_directory_register.append(study_location)
+                return []
             elif len(maf_file_list) is 0:
                 self.missing_maf_register.append(study_id)
                 return maf_file_list

--- a/app/ws/report_builders/combined_maf_builder.py
+++ b/app/ws/report_builders/combined_maf_builder.py
@@ -20,7 +20,8 @@ class CombinedMafBuilder:
         self.studies_to_combine = studies_to_combine
         self.original_study_location = original_study_location
         self.method = method
-        self.missed_maf_register = []
+        self.unopenable_maf_register = []
+        self.missing_maf_register = []
         self.missing_study_directory_register = []
         self.no_relevant_maf_register = []
 
@@ -77,11 +78,11 @@ class CombinedMafBuilder:
                     maf_temp = pandas.read_csv(os.path.join(study_location, maf), sep="\t", header=0, encoding='unicode_escape')
                 except pandas.errors.EmptyDataError as e:
                     logger.error(f'EmptyDataError Issue with opening maf file {maf}: {str(e)}')
-                    self.missed_maf_register.append(maf)
+                    self.unopenable_maf_register.append(maf)
                     continue
                 except Exception as e:
                     logger.error(f'Issue with opening maf file {maf}, cause of error unclear: {str(e)}')
-                    self.missed_maf_register.append(maf)
+                    self.unopenable_maf_register.append(maf)
                     continue
 
                 cleanup_function = getattr(DataFrameUtils, f'{self.method}_maf_cleanup')
@@ -124,7 +125,8 @@ class CombinedMafBuilder:
             if maf_file_list is None:
                 self.missing_study_directory_register.append(study_location)
             if len(maf_file_list) is 0:
-                self.missed_maf_register.append(maf_file_list)
+                self.missing_maf_register.append(study_id)
+                return maf_file_list
 
 
         logger.info(f'maf_file_list {str(maf_file_list)}')

--- a/app/ws/report_builders/combined_maf_builder.py
+++ b/app/ws/report_builders/combined_maf_builder.py
@@ -21,6 +21,7 @@ class CombinedMafBuilder:
         self.original_study_location = original_study_location
         self.method = method
         self.missed_maf_register = []
+        self.missing_study_directory_register = []
 
     def build(self):
         """
@@ -103,11 +104,20 @@ class CombinedMafBuilder:
             'LCMS': ['LC', 'LC-MS', 'LCMS', 'spectrometry']
         }
         maf_file_list = None
+        logger.info(f'current directory: {os.getcwd()}')
+        os.chdir(study_location)
         try:
-            maf_file_list = [file for file in os.listdir(study_location) if
+            maf_file_list = [file for file in os.listdir() if
                              file.startswith('m_') and file.endswith('.txt')]
+        except FileNotFoundError as e:
+            logger.error(f'FileNotFoundError: {str(e)}')
+        except NotADirectoryError as e:
+            logger.error(f'NotADirectoryError: {str(e)}')
         except Exception as e:
             logger.error(f'Unexpected error: {str(e)}')
+        finally:
+            if maf_file_list is None:
+                self.missing_study_directory_register.append(study_location)
 
         logger.info(f'maf_file_list {str(maf_file_list)}')
         if maf_file_list.__len__() > 1:

--- a/app/ws/report_builders/combined_maf_builder.py
+++ b/app/ws/report_builders/combined_maf_builder.py
@@ -124,14 +124,14 @@ class CombinedMafBuilder:
             if maf_file_list is None:
                 self.missing_study_directory_register.append(study_location)
             if len(maf_file_list) is 0:
-                self.no_relevant_maf_register.append(study_id)
+                self.missed_maf_register.append(maf_file_list)
 
 
         logger.info(f'maf_file_list {str(maf_file_list)}')
-        if len(maf_file_list) > 1:
-            filtered_maf_list = [file for file in maf_file_list if
-                                 any(token.upper() in file.upper() for token in tokens[self.method])]
-        else:
-            filtered_maf_list = maf_file_list
+        filtered_maf_list = [file for file in maf_file_list if
+                             any(token.upper() in file.upper() for token in tokens[self.method])]
+        if len(filtered_maf_list) is 0:
+            self.no_relevant_maf_register.append(study_id)
+
         logger.info(f'filtered_maf_list {str(filtered_maf_list)}')
         return filtered_maf_list

--- a/app/ws/report_builders/combined_maf_builder.py
+++ b/app/ws/report_builders/combined_maf_builder.py
@@ -1,0 +1,82 @@
+import logging
+import os
+import pandas
+
+from typing import List
+from flask import current_app as app, abort
+from app.ws.misc_utilities.dataframe_utils import DataFrameUtils
+from app.ws.utils import totuples
+
+logger = logging.getLogger('wslog')
+
+
+class CombinedMafBuilder:
+
+    def __init__(self, studies_to_combine: List[str], original_study_location: str, method: str):
+        self.studies_to_combine = studies_to_combine
+        self.original_study_location = original_study_location
+        self.method = method
+        self.missed_maf_register = []
+
+    def build(self):
+        list_of_mafs = []
+        maf_generator = self.get_dataframe()
+
+        for maf_as_dict in maf_generator:
+            list_of_mafs.extend(maf_as_dict)
+
+        reporting_path = app.config.get('MTBLS_FTP_ROOT') + app.config.get('REPORTING_PATH') + 'global/'
+
+        combined_maf = pandas.DataFrame(list_of_mafs)
+        try:
+            combined_maf.to_csv(
+                    os.path.join(reporting_path, f'{self.method}_combined_maf.tsv'),
+                    sep="\t",
+                    encoding='utf-8',
+                    index='false'
+                )
+        except Exception as e:
+            # bad practice here catching base exception, but the pandas documentation did not reveal what errors or
+            # exceptions to expect
+            logger.error(f'Problem writing the combined maf file to csv:{str(e)}')
+            abort(500)
+
+
+
+    def get_dataframe(self):
+        """
+
+        """
+        for study_id in self.studies_to_combine:
+            study_location = self.original_study_location.replace("MTBLS1", study_id)
+            for maf in self.sort_mafs(study_location):
+                maf_temp = None
+                try:
+                    maf_temp = pandas.read_csv(os.path.join(study_location, maf), sep="\t", header=0, encoding='unicode_escape')
+                except pandas.errors.EmptyDataError as e:
+                    logger.error(f'EmptyDataError Issue with opening maf file {maf}: {str(e)}')
+                    self.missed_maf_register.append(maf)
+                    continue
+                cleanup_function = getattr(DataFrameUtils, f'{self.method}_maf_cleanup')
+                maf_temp = cleanup_function(maf_temp)
+                maf_as_dict = totuples(df=maf_temp, text='dict')['dict']
+                yield maf_as_dict
+
+            # assuming that a maf has been found as they have been hand selected
+
+
+    def sort_mafs(self, study_location):
+        filtered_maf_list = []
+        tokens = {
+            'NMR': ['NMR', 'spectroscopy'],
+            'LCMS': ['LC', 'LC-MS', 'LCMS', 'spectrometry']
+        }
+        maf_file_list = [file for file in os.listdir(study_location) if
+                         file.startswith('m_') and file.endswith('.txt')]
+        if maf_file_list.__len__() > 1:
+            filtered_maf_list = [file for file in maf_file_list if
+                                 any(token.upper() in file.upper() for token in tokens[self.method])]
+        else:
+            filtered_maf_list = maf_file_list
+
+        return filtered_maf_list

--- a/app/ws/report_builders/combined_maf_builder.py
+++ b/app/ws/report_builders/combined_maf_builder.py
@@ -101,7 +101,6 @@ class CombinedMafBuilder:
         :param study_location: The location in the filesystem of the study, as a string.
         :return: A List of strings representing culled filenames.
         """
-        #study_location = study_location.strip("'")
         logger.error(f'hit sorts maf for {study_location}, method: {self.method}')
         filtered_maf_list = []
         tokens = {
@@ -110,7 +109,7 @@ class CombinedMafBuilder:
         }
         maf_file_list = None
         logger.info(f'current directory: {os.getcwd()}')
-        # os.chdir(study_location)
+
         try:
             logger.info(str([file for file in os.listdir(study_location)]))
             maf_file_list = [file for file in os.listdir(study_location) if

--- a/app/ws/report_builders/combined_maf_builder.py
+++ b/app/ws/report_builders/combined_maf_builder.py
@@ -11,6 +11,9 @@ logger = logging.getLogger('wslog')
 
 
 class CombinedMafBuilder:
+    """
+    Builds a combined maf files from a given list of studies.
+    """
 
     def __init__(self, studies_to_combine: List[str], original_study_location: str, method: str):
         self.studies_to_combine = studies_to_combine
@@ -19,6 +22,10 @@ class CombinedMafBuilder:
         self.missed_maf_register = []
 
     def build(self):
+        """
+        Entry method to the class. Gets the generator that yields individual maf dicts, and adds that dict to the list.
+        We then try and create a new DataFrame object from that list of dicts.
+        """
         list_of_mafs = []
         maf_generator = self.get_dataframe()
 
@@ -45,7 +52,12 @@ class CombinedMafBuilder:
 
     def get_dataframe(self):
         """
+        Yield an individual dataframe-as-a-dict. This is a generator method, with the idea being that with such massive files
+        we want to limit how many dataframes we are holding in memory at once. We convert the dataframe to a dict in this method,
+        and then yield it. This means we only have one dataframe open in memory at a time.
 
+        The method also sorts through each of the maf files found in the study directory, attempting to cast off any
+        that might correspond to other analytical methods.
         """
         for study_id in self.studies_to_combine:
             study_location = self.original_study_location.replace("MTBLS1", study_id)
@@ -66,6 +78,12 @@ class CombinedMafBuilder:
 
 
     def sort_mafs(self, study_location):
+        """
+        Sorts through study directory maf files by checking for the presence of 'tokens' in the filename.
+
+        :param study_location: The location in the filesystem of the study, as a string.
+        :return: A List of strings representing culled filenames.
+        """
         filtered_maf_list = []
         tokens = {
             'NMR': ['NMR', 'spectroscopy'],

--- a/logging.conf
+++ b/logging.conf
@@ -2,7 +2,7 @@
 keys=root,werkzeug,wslog,wslog_chebi
 
 [handlers]
-keys=trfHandler,chebiHandler
+keys=trfHandler,chebiHandler,builderHandler
 
 [formatters]
 keys=extFormatter
@@ -30,6 +30,12 @@ handlers=chebiHandler
 qualname=wslog_chebi
 propagate=0
 
+[logger_builder]
+level=DEBUG
+handlers=builderHandler
+qualname=builder
+propagate=0
+
 [handler_trfHandler]
 class=handlers.TimedRotatingFileHandler
 level=DEBUG
@@ -41,6 +47,12 @@ class=handlers.TimedRotatingFileHandler
 level=INFO
 formatter=extFormatter
 args=('logs/ws_chebi_pipeline.log', 'midnight')
+
+[handler_builderHandler]
+class=handlers.TimedRotatingFileHandler
+level=INFO
+formatter=extFormatter
+args=('logs/ws_builders.log', 'midnight')
 
 [formatter_extFormatter]
 class=logging.Formatter

--- a/logging_wp-np3-15.ebi.ac.uk.conf
+++ b/logging_wp-np3-15.ebi.ac.uk.conf
@@ -1,8 +1,8 @@
 [loggers]
-keys=root,werkzeug,wslog,wslog_chebi
+keys=root,werkzeug,wslog,wslog_chebi,builder
 
 [handlers]
-keys=trfHandler,chebiHandler
+keys=trfHandler,chebiHandler, builderHandler
 
 [formatters]
 keys=extFormatter
@@ -30,6 +30,12 @@ handlers=chebiHandler
 qualname=wslog_chebi
 propagate=0
 
+[logger_builder]
+level=DEBUG
+handlers=builderHandler
+qualname=builder
+propagate=0
+
 [handler_trfHandler]
 class=handlers.TimedRotatingFileHandler
 level=DEBUG
@@ -41,6 +47,12 @@ class=handlers.TimedRotatingFileHandler
 level=INFO
 formatter=extFormatter
 args=('logs/ws_chebi_pipeline_wp-np3-15.log', 'midnight')
+
+[handler_builderHandler]
+class=handlers.TimedRotatingFileHandler
+level=INFO
+formatter=extFormatter
+args=('logs/ws_builders_wp-np3-15.log', 'midnight')
 
 [formatter_extFormatter]
 class=logging.Formatter

--- a/logging_wp-p3s-15.ebi.ac.uk.conf
+++ b/logging_wp-p3s-15.ebi.ac.uk.conf
@@ -1,8 +1,8 @@
 [loggers]
-keys=root,werkzeug,wslog,wslog_chebi
+keys=root,werkzeug,wslog,wslog_chebi,builder
 
 [handlers]
-keys=trfHandler,chebiHandler
+keys=trfHandler,chebiHandler,builderHandler
 
 [formatters]
 keys=extFormatter
@@ -30,6 +30,12 @@ handlers=chebiHandler
 qualname=wslog_chebi
 propagate=0
 
+[logger_builder]
+level=DEBUG
+handlers=builderHandler
+qualname=builder
+propagate=0
+
 [handler_trfHandler]
 class=handlers.TimedRotatingFileHandler
 level=DEBUG
@@ -41,6 +47,12 @@ class=handlers.TimedRotatingFileHandler
 level=INFO
 formatter=extFormatter
 args=('logs/ws_chebi_pipeline_wp-p3s-15.log', 'midnight')
+
+[handler_builderHandler]
+class=handlers.TimedRotatingFileHandler
+level=INFO
+formatter=extFormatter
+args=('logs/ws_builders_wp-p3s-15.log', 'midnight')
 
 [formatter_extFormatter]
 class=logging.Formatter

--- a/logging_wp-p3s-19.ebi.ac.uk.conf
+++ b/logging_wp-p3s-19.ebi.ac.uk.conf
@@ -1,8 +1,8 @@
 [loggers]
-keys=root,werkzeug,wslog,wslog_chebi
+keys=root,werkzeug,wslog,wslog_chebi,builder
 
 [handlers]
-keys=trfHandler,chebiHandler
+keys=trfHandler,chebiHandler,builderHandler
 
 [formatters]
 keys=extFormatter
@@ -30,6 +30,12 @@ handlers=chebiHandler
 qualname=wslog_chebi
 propagate=0
 
+[logger_builder]
+level=DEBUG
+handlers=builderHandler
+qualname=builder
+propagate=0
+
 [handler_trfHandler]
 class=handlers.TimedRotatingFileHandler
 level=DEBUG
@@ -41,6 +47,12 @@ class=handlers.TimedRotatingFileHandler
 level=INFO
 formatter=extFormatter
 args=('logs/ws_chebi_pipeline_wp-p3s-19.log', 'midnight')
+
+[handler_builderHandler]
+class=handlers.TimedRotatingFileHandler
+level=INFO
+formatter=extFormatter
+args=('logs/ws_builders_wp-p3s-19.log', 'midnight')
 
 [formatter_extFormatter]
 class=logging.Formatter

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,13 +29,12 @@ numpy==1.18.2
 oauth2client==4.1.3
 owlready2==0.23
 pandas==0.25.3
-psycopg2==2.8.6
 psycopg2-binary==2.8.6
+psycopg2==2.8.6
 pubchempy==1.0.4
 pronto==0.12.2
 pyopenms==2.4.0
 python-Levenshtein==0.12.2
-pyopenms==2.6.0
 plotly==4.6.0
 pillow==7.1.1
 requests==2.23.0

--- a/wsapp.py
+++ b/wsapp.py
@@ -146,6 +146,7 @@ def initialize_app(flask_app):
 
     # Metabolite Annotation File (MAF)
     api.add_resource(MetaboliteAnnotationFile, res_path + "/studies/<string:study_id>/maf/validate")
+    api.add_resource(CombineMetaboliteAnnotationFiles, res_path + "/ebi-internal/mariana/maf/combine")
 
     # Study
     # api.add_resource(StudySources, res_path + "/studies/<string:study_id>/sources")


### PR DESCRIPTION
Squashed some commits for brevity. Builds a combined maf file from an input list of study accession numbers. This can be triggered via the new API endpoint. Built file is deposited in the reporting directory.  A follow up ticket could have this file deposited to the MARIANA google drive instead.