### PR TITLE
2 Chebi WS endpoint is added

### DIFF
--- a/app/ws/chebi/models.py
+++ b/app/ws/chebi/models.py
@@ -1,0 +1,80 @@
+from typing import List, Any
+
+from pydantic import BaseModel, Field
+
+
+class CommentDataItem(BaseModel):
+    text: str = None
+    date: str = None
+
+
+class DataItem(BaseModel):
+    data: str = None
+    type: str = None
+    source: str = None
+    comments: List[CommentDataItem] = []
+
+
+class StructureDataItem(BaseModel):
+    structure: str = None
+    type: str = None
+    dimension: str = None
+    defaultStructure: bool = True
+    comments: List[CommentDataItem] = []
+
+
+class OntologyDataItem(BaseModel):
+    chebiName: str = None
+    chebiId: str = None
+    type: str = None
+    status: str = None
+    cyclicRelationship: bool = False
+    comments: List[CommentDataItem] = []
+    ontologyElement: List[Any] = []
+
+
+class CompoundOriginDataItem(BaseModel):
+    speciesText: str = None
+    speciesAccession: str = None
+    componentText: str = None
+    componentAccession: str = None
+    strainText: str = None
+    strainAccession: str = None
+    sourceType: str = None
+    sourceAccession: str = None
+
+
+class LiteEntity(BaseModel):
+    chebiId: str = None
+    chebiAsciiName: str = None
+    entityStar: int = 0
+    searchScore: float = 0
+
+class Entity(BaseModel):
+    chebiId: str = None
+    chebiAsciiName: str = None
+    definition: str = None
+    status: str = None
+    smiles: str = None
+    inchi: str = None
+    inchiKey: str = None
+    charge: str = None
+    mass: str = None
+    monoisotopicMass: str = None
+    entityStar: int = 0
+
+    secondaryChEBIIds: List[str] = Field([], alias="SecondaryChEBIIds")
+    synonyms: List[DataItem] = Field([], alias="Synonyms")
+    iupacNames: List[DataItem] = Field([], alias="IupacNames")
+    formulae: List[DataItem] = Field([], alias="Formulae")
+    registryNumbers: List[DataItem] = Field([], alias="RegistryNumbers")
+    citations: List[DataItem] = Field([], alias="Citations")
+    chemicalStructures: List[StructureDataItem] = Field([], alias="ChemicalStructures")
+    databaseLinks: List[DataItem] = Field([], alias="DatabaseLinks")
+    ontologyParents: List[OntologyDataItem] = Field([], alias="OntologyParents")
+    ontologyChildren: List[OntologyDataItem] = Field([], alias="OntologyChildren")
+    generalComments: List[CommentDataItem] = Field([], alias="GeneralComments")
+    compoundOrigins: List[CompoundOriginDataItem] = Field([], alias="CompoundOrigins")
+
+    class Config:
+        allow_population_by_field_name = True

--- a/app/ws/chebi/settings.py
+++ b/app/ws/chebi/settings.py
@@ -1,0 +1,22 @@
+from functools import lru_cache
+
+from pydantic import BaseSettings
+
+
+class ChebiWsSettings(BaseSettings):
+    chebi_ws_wsdl: str = "https://www.ebi.ac.uk/webservices/chebi/2.0/webservice?wsdl"
+    chebi_ws_wsdl_service: str = 'ChebiWebServiceService'
+    chebi_ws_wsdl_service_port: str = 'ChebiWebServicePort'
+    chebi_ws_strict: bool = False
+    chebi_ws_xml_huge_tree: bool = True
+    chebi_ws_service_binding_log_level: str = "ERROR"
+
+
+    class Config:
+        # read and set settings variables from this env_file
+        env_file = ".env"
+
+
+@lru_cache
+def get_chebi_ws_settings():
+    return ChebiWsSettings()

--- a/app/ws/chebi/types.py
+++ b/app/ws/chebi/types.py
@@ -1,0 +1,49 @@
+from enum import Enum
+
+
+class SearchCategory(str, Enum):
+    ALL = "ALL"
+    CHEBI_ID = "CHEBI ID"
+    CHEBI_NAME = "CHEBI NAME"
+    DEFINITION = "DEFINITION"
+    ALL_NAMES = "ALL NAMES"
+    IUPAC_NAME = "IUPAC NAME"
+    DATABASE_LINK_REGISTRY_NUMBER_CITATION = "DATABASE LINK/REGISTRY NUMBER/CITATION"
+    FORMULA = "FORMULA"
+    MASS = "MASS"
+    MONOISOTOPIC_MASS = "MONOISOTOPIC MASS"
+    CHARGE = "CHARGE"
+    INCHI_INCHI_KEY = "INCHI/INCHI KEY"
+    SMILES = "SMILES"
+    SPECIES = "SPECIES"
+
+
+class StarsCategory(str, Enum):
+    ALL = "ALL"
+    TWO_ONLY = "TWO ONLY"
+    THREE_ONLY = "THREE ONLY"
+
+
+class RelationshipType(str, Enum):
+    IS_A = "is a"
+    HAS_PART = "has part"
+    IS_CONJUGATE_BASE_OF = "is conjugate base of"
+    IS_CONJUGATE_ACID_OF = "is conjugate acid of"
+    IS_TAUTOMER_OF = "is tautomer of"
+    IS_ENANTIOMER_OF = "is enantiomer of"
+    HAS_FUNCTIONAL_PARENT = "has functional parent"
+    HAS_PARENT_HYDRIDE = "has parent hydride"
+    IS_SUBSTITUENT_GROUP_FROM = "is substituent group from"
+    HAS_ROLE = "has role"
+
+
+class StructureType(str, Enum):
+    MOLFILE = "MOLFILE"
+    CML = "CML"
+    SMILES = "SMILES"
+
+
+class StructureSearchCategory(str, Enum):
+    IDENTITY = "IDENTITY"
+    SUBSTRUCTURE = "SUBSTRUCTURE"
+    SIMILARITY = "SIMILARITY"

--- a/app/ws/chebi/wsproxy.py
+++ b/app/ws/chebi/wsproxy.py
@@ -1,0 +1,153 @@
+import logging
+from typing import List, Optional
+
+from zeep import Client, Settings, helpers
+from zeep.exceptions import Fault
+
+from app.ws.chebi.models import Entity, LiteEntity, OntologyDataItem
+from app.ws.chebi.settings import ChebiWsSettings, get_chebi_ws_settings
+from app.ws.chebi.types import SearchCategory, StarsCategory, RelationshipType, StructureType, \
+    StructureSearchCategory
+
+
+class ChebiWsException(Exception):
+    def __init__(self, message):
+        self.message = message
+
+
+def ws_fault_exception_handler(func):
+    def exception_handler(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Fault as e:
+            raise ChebiWsException(message=e.message)
+
+    return exception_handler
+
+
+class ChebiWsProxy(object):
+
+    def __init__(self, settings: ChebiWsSettings = None):
+
+        self.settings = settings
+        if not self.settings:
+            self.settings = ChebiWsSettings()
+
+        if self.settings.chebi_ws_service_binding_log_level == "WARNING":
+            zeep_operation_log_level = logging.WARNING
+        elif self.settings.chebi_ws_service_binding_log_level == "ERROR":
+            zeep_operation_log_level = logging.ERROR
+        else:
+            zeep_operation_log_level = logging.WARNING
+
+        client_settings = Settings(strict=self.settings.chebi_ws_strict, xml_huge_tree=self.settings.chebi_ws_xml_huge_tree)
+        logging.getLogger('zeep.wsdl.bindings.soap').setLevel(zeep_operation_log_level)
+        try:
+            self.client = Client(self.settings.chebi_ws_wsdl, settings=client_settings)
+            self.service = self.client.bind(self.settings.chebi_ws_wsdl_service, self.settings.chebi_ws_wsdl_service_port)
+        except Fault as e:
+            raise ChebiWsException(message=e.message)
+        except ValueError as e:
+            raise ChebiWsException(message=e.args)
+
+
+    @ws_fault_exception_handler
+    def get_complete_entity(self, chebi_id: str) -> Optional[Entity]:
+        result = self.service.getCompleteEntity(chebi_id)
+        serialized_result = helpers.serialize_object(result, dict)
+
+        if serialized_result:
+            data = Entity.parse_obj(serialized_result)
+            return data
+        return None
+
+    @ws_fault_exception_handler
+    def get_lite_entity_list(self, search_text: str, search_category: SearchCategory,
+                             maximum_results: int, stars: StarsCategory) -> Optional[List[LiteEntity]]:
+        result = self.service.getLiteEntity(search_text, search_category.value, maximum_results, stars.value)
+        serialized_result = helpers.serialize_object(result, dict)
+        if serialized_result:
+            result = [LiteEntity.parse_obj(data) for data in serialized_result]
+            return result
+        return None
+
+    @ws_fault_exception_handler
+    def get_complete_entity_by_list(self, chebi_id_list: List[str]) -> Optional[List[Entity]]:
+        service_result = self.service.getCompleteEntityByList(chebi_id_list)
+        serialized_result = helpers.serialize_object(service_result, dict)
+        if serialized_result:
+            result = [Entity.parse_obj(data) for data in serialized_result]
+            return result
+        return None
+
+    @ws_fault_exception_handler
+    def get_ontology_parents(self, chebi_id: str) -> Optional[List[OntologyDataItem]]:
+        service_result = self.service.getOntologyParents(chebi_id)
+        serialized_result = helpers.serialize_object(service_result, dict)
+        if serialized_result:
+            result = [OntologyDataItem.parse_obj(data) for data in serialized_result]
+            return result
+        return None
+
+    @ws_fault_exception_handler
+    def get_ontology_children(self, chebi_id: str) -> Optional[List[OntologyDataItem]]:
+        service_result = self.service.getOntologyChildren(chebi_id)
+        serialized_result = helpers.serialize_object(service_result, dict)
+        if serialized_result:
+            result = [OntologyDataItem.parse_obj(data) for data in serialized_result]
+            return result
+        return None
+
+    @ws_fault_exception_handler
+    def get_all_ontology_children_in_path(self, chebi_id: str, relationship_type: RelationshipType,
+                                          structure_only: bool) -> Optional[List[LiteEntity]]:
+        service_result = self.service.getAllOntologyChildrenInPath(chebi_id, relationship_type.value, structure_only)
+        serialized_result = helpers.serialize_object(service_result, dict)
+        if serialized_result:
+            result = [LiteEntity.parse_obj(data) for data in serialized_result]
+            return result
+        return None
+
+    @ws_fault_exception_handler
+    def get_structure_search(self, structure: str, structure_type: StructureType,
+                             structure_search_category: StructureSearchCategory,
+                             total_results: int, tanimoto_cutoff: float) -> Optional[List[LiteEntity]]:
+
+        service_result = self.service.getStructureSearch(structure, structure_type,
+                                                         structure_search_category,
+                                                         total_results, tanimoto_cutoff)
+
+        serialized_result = helpers.serialize_object(service_result, dict)
+        if serialized_result:
+            result = [Entity.parse_obj(data) for data in serialized_result]
+            return result
+        return None
+
+
+if __name__ == "__main__":
+    def test_chebi_ws():
+        chebi_ws_proxy = ChebiWsProxy(get_chebi_ws_settings())
+
+        ws_result = chebi_ws_proxy.get_structure_search("C[C@H](CCC=C(C)C)c1ccc(C)cc1",
+                                                        structure_type=StructureType.SMILES.value,
+                                                        structure_search_category=StructureSearchCategory.SIMILARITY.value,
+                                                        total_results=200,
+                                                        tanimoto_cutoff=float(0.8))
+        print(ws_result)
+
+        ws_result = chebi_ws_proxy.get_complete_entity_by_list(["CHEBI:10225", "CHEBI:102265"])
+        print(ws_result)
+        ws_result = chebi_ws_proxy.get_complete_entity("CHEBI:10225000")
+        print(ws_result)
+        ws_result = chebi_ws_proxy.get_ontology_parents("CHEBI:10225")
+        print(ws_result)
+        ws_result = chebi_ws_proxy.get_ontology_children("CHEBI:10225")
+        print(ws_result)
+        ws_result = chebi_ws_proxy.get_all_ontology_children_in_path("CHEBI:10225",
+                                                                     RelationshipType.HAS_ROLE, structure_only=False)
+        print(ws_result)
+        ws_result = chebi_ws_proxy.get_lite_entity("CHEBI:10225", SearchCategory.CHEBI_ID, 200, StarsCategory.ALL)
+        print(ws_result)
+
+
+    test_chebi_ws()

--- a/app/ws/chebi_ws.py
+++ b/app/ws/chebi_ws.py
@@ -1,0 +1,110 @@
+import logging
+
+from flask import request, abort
+from flask_restful import Resource
+from flask_restful_swagger import swagger
+
+from app.ws.chebi.types import SearchCategory, StarsCategory
+from app.ws.chebi.wsproxy import ChebiWsProxy, ChebiWsException
+from app.ws.utils import log_request
+
+logger = logging.getLogger(__file__)
+chebi_proxy = ChebiWsProxy()
+
+responseMessages = [
+    {
+        "code": 200,
+        "message": "OK."
+    },
+    {
+        "code": 400,
+        "message": "Bad Request. Server could not understand the request due to malformed syntax."
+    },
+    {
+        "code": 404,
+        "message": "Not found. The requested identifier is not valid or does not exist."
+    },
+    {
+        "code": 501,
+        "message": "Server error."
+    },
+]
+
+
+class ChebiLiteEntity(Resource):
+
+    @swagger.operation(
+        summary="Get Chebi ID with name",
+        nickname="Get Chebi ID with name",
+        notes="Get Chebi ID with name",
+        parameters=[
+            {
+                "name": "compound_name",
+                "description": "Compound Name",
+                "required": True,
+                "allowMultiple": False,
+                "paramType": "path",
+                "dataType": "string"
+            }
+        ],
+        responseMessages=responseMessages
+    )
+    def get(self, compound_name):
+        log_request(request)
+
+        if not compound_name:
+            abort(400, "Invalid compound name")
+
+        if not chebi_proxy:
+            abort(501, "Remote server error")
+
+        try:
+            search_result = chebi_proxy.get_lite_entity_list(compound_name.lower(), SearchCategory.ALL_NAMES, 20,
+                                                             StarsCategory.ALL)
+
+            if not search_result:
+                return abort(404, f"Entity not found with name {compound_name}")
+
+            result = list()
+            for search in search_result:
+                result.append(search.dict())
+            return result
+        except ChebiWsException as e:
+            abort(501, "Remote server error")
+
+
+class ChebiEntity(Resource):
+    @swagger.operation(
+        summary="Get details of compound with Chebi ID",
+        nickname="Get details of compound with Chebi ID",
+        notes="Get details of compound with Chebi ID",
+        parameters=[
+            {
+                "name": "chebi_id",
+                "description": "ChEBI ID",
+                "required": True,
+                "allowMultiple": False,
+                "paramType": "path",
+                "dataType": "string"
+            }
+        ],
+        responseMessages=responseMessages
+    )
+    def get(self, chebi_id):
+        log_request(request)
+
+        if not chebi_id:
+            abort(400, "Invalid ChEBI id")
+
+        if not chebi_proxy:
+            abort(501, "Remote server error")
+
+        try:
+            search_result = chebi_proxy.get_complete_entity(chebi_id)
+
+            if not search_result:
+                return abort(404, f"Entity not found with ChEBI id {chebi_id}")
+
+            return search_result.dict()
+        except ChebiWsException as e:
+            abort(501, "Remote server error")

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,4 +41,4 @@ requests==2.23.0
 recommonmark==0.6.0
 xmltodict==0.12.0
 zeep==3.4.0
-
+pydantic==1.9.0

--- a/wsapp.py
+++ b/wsapp.py
@@ -29,6 +29,7 @@ from app.ws.assay_protocol import *
 from app.ws.assay_table import *
 from app.ws.biostudies import *
 from app.ws.chebi_workflow import SplitMaf, ChEBIPipeLine, ChEBIPipeLineLoad
+from app.ws.chebi_ws import ChebiLiteEntity, ChebiEntity
 from app.ws.cluster_jobs import LsfUtils, LsfUtilsStatus
 from app.ws.compare_files import CompareTsvFiles
 from app.ws.cronjob import *
@@ -213,6 +214,9 @@ def initialize_app(flask_app):
     api.add_resource(StudyAssayTypeReports, res_path + "/v2/study-assay-type-reports")
     api.add_resource(curation_log, res_path + "/v2/curation_log")
 
+    api.add_resource(ChebiLiteEntity, res_path + "/chebi/chebi-ids/<string:compound_name>")
+    api.add_resource(ChebiEntity, res_path + "/chebi/entities/<string:chebi_id>")
+
     # ToDo, complete this: api.add_resource(CheckCompounds, res_path + "/ebi-internal/compound-names")
 
 
@@ -222,7 +226,7 @@ def main():
     logger.info("Starting server %s v%s", application.config.get('WS_APP_NAME'),
                 application.config.get('WS_APP_VERSION'))
     # application.run(host="0.0.0.0", port=config.PORT, debug=config.DEBUG, ssl_context=context)
-    print("Starting application")
+    print("Starting application on port %s" % str(application.config.get('PORT')))
     application.run(host="0.0.0.0", port=application.config.get('PORT'), debug=application.config.get('DEBUG'),
                     threaded=True)
     logger.info("Finished server %s v%s", application.config.get('WS_APP_NAME'),


### PR DESCRIPTION
Python based chebi proxy is created. It has same methods as Java Chebi Proxy in Java project.
Two endpoints are implemented
1) /chebi/chebi-ids/<string:compound_name>
2) /chebi/entities/<string:chebi_id>

Users can search chebi name using first endpoint and then get details with second one. Second one also returns secondary chebi ids of entity, inchi, inchi keys, etc.