### PR TITLE
returning parser obj in europe_pmc_parser where previously we weren't

### DIFF
--- a/app/ws/misc_utilities/request_parsers.py
+++ b/app/ws/misc_utilities/request_parsers.py
@@ -14,6 +14,7 @@ class RequestParsers:
     def europepmc_report_parser():
         parser = reqparse.RequestParser()
         parser.add_argument('google_drive', help='Save the report to google drive instead of the vm?')
+        return parser
 
     @staticmethod
     def study_type_report_parser():


### PR DESCRIPTION
return statement was missing, causing an error when we tried call `.parse_args`