### PR TITLE
MTBLS-75 reindex task runs in thread

### DIFF
--- a/app/ws/db/models.py
+++ b/app/ws/db/models.py
@@ -17,6 +17,22 @@ class IndexedUserModel(BaseModel):
         orm_mode = True
 
 
+class StudyTaskModel(BaseModel):
+    id: int = Field(0)
+    study_acc: str = Field(None)
+    task_name: str = Field(None)
+    last_request_time: datetime.datetime = Field(None)
+    last_request_executed: datetime.datetime = Field(None)
+    last_execution_time: datetime.datetime = Field(None)
+    last_execution_status: str = Field(None)
+    last_execution_message: str = Field(None)
+
+    class Config:
+        orm_mode = True
+        json_encoders = {
+            datetime.datetime: lambda v: v.timestamp(),
+        }
+
 class UserModel(BaseModel):
     address: str = Field(None, alias="address")  # excluded from es
     affiliation: str = Field(None, alias="affiliation")  # excluded from es

--- a/app/ws/db/schemes.py
+++ b/app/ws/db/schemes.py
@@ -7,6 +7,21 @@ Base = declarative_base()
 metadata = Base.metadata
 
 
+class StudyTask(Base):
+    __tablename__ = 'study_tasks'
+
+    id = Column(BigInteger, primary_key=True)
+    study_acc = Column(String(255), nullable=False)
+    task_name = Column(String(255), nullable=False)
+    last_request_time = Column(DateTime, nullable=False)
+    last_request_executed = Column(DateTime, nullable=False)
+    last_execution_time = Column(String(255), nullable=False)
+    last_execution_status = Column(String(255), nullable=False)
+    last_execution_message = Column(Text)
+    UniqueConstraint('study_acc', 'task_name'),
+    Index('ref_xref_acc_task', 'study_acc', 'task_name', unique=True)
+
+
 class RegisteredUserView(Base):
     __tablename__ = 'registered_users_view'
 

--- a/app/ws/db/types.py
+++ b/app/ws/db/types.py
@@ -22,3 +22,15 @@ class StudyStatus(Enum):
     INREVIEW = 2
     PUBLIC = 3
     DORMANT = 4
+
+
+class StudyTaskStatus(str, Enum):
+    NOT_EXECUTED = 'NOT_EXECUTED'
+    EXECUTING = 'EXECUTING'
+    EXECUTION_SUCCESSFUL = 'EXECUTION_SUCCESSFUL'
+    EXECUTION_FAILED = 'EXECUTION_FAILED'
+
+
+class StudyTaskName(str, Enum):
+    REINDEX = 'REINDEX'
+    SEND_TWEET = 'SEND_TWEET'

--- a/app/ws/mtblsWSclient.py
+++ b/app/ws/mtblsWSclient.py
@@ -121,7 +121,7 @@ class WsClient:
 
         UserService.get_instance(app).validate_user_has_submitter_or_super_user_role(user_token)
         try:
-            indexed_data = self.elasticsearch_service.reindex_study(study_id, user_token, include_validation_results)
-            return True, f" {indexed_data.studyIdentifier} is successfully indexed"
+            self.elasticsearch_service.reindex_study(study_id, user_token, include_validation_results)
+            return True, f" {study_id} is successfully indexed"
         except MetabolightsException as e:
             abort(501, e.message)

--- a/app/ws/study/study_service.py
+++ b/app/ws/study/study_service.py
@@ -2,7 +2,7 @@ from flask import current_app as app
 
 from app.utils import MetabolightsDBException, MetabolightsFileOperationException
 from app.ws.db.dbmanager import DBManager
-from app.ws.db.schemes import Study, User, Stableid
+from app.ws.db.schemes import Study, User, Stableid, StudyTask
 from app.ws.db.settings import get_directory_settings
 from app.ws.db.types import UserStatus, UserRole, StudyStatus
 from app.ws.db.wrappers import create_study_model_from_db_study, update_study_model_from_directory
@@ -87,3 +87,16 @@ class StudyService(object):
                 return study_id_list
 
         return []
+
+    def get_study_tasks(self, study_id, task_name=None):
+        try:
+            with self.db_manager.session_maker() as db_session:
+                query = db_session.query(StudyTask)
+                if task_name:
+                    filtered = query.filter(StudyTask.study_acc == study_id and StudyTask.task_name == task_name)
+                else:
+                    filtered = query.filter(StudyTask.study_acc == study_id)
+                result = filtered.all()
+                return result
+        except Exception as e:
+            raise MetabolightsDBException(message=f"Error while retreiving study tasks from database: {str(e)}", exception=e)

--- a/app/wsapp_config.py
+++ b/app/wsapp_config.py
@@ -53,7 +53,8 @@ from app.ws.jira_update import Jira
 from app.ws.metaspace_pipeline import MetaspacePipeLine
 from app.ws.mtblsStudy import MtblsStudies, MtblsPrivateStudies, MtblsStudiesWithMethods, MyMtblsStudiesDetailed, \
     MyMtblsStudies, IsaTabInvestigationFile, IsaTabSampleFile, IsaTabAssayFile, CreateAccession, CloneAccession, \
-    DeleteStudy, CreateUploadFolder, AuditFiles, ReindexStudy, ReindexAllPublicStudies, MtblsStudyValidationStatus
+    DeleteStudy, CreateUploadFolder, AuditFiles, ReindexStudy, ReindexAllPublicStudies, MtblsStudyValidationStatus, \
+    UnindexedStudy
 from app.ws.mtblsWSclient import WsClient
 from app.ws.mtbls_maf import MtblsMAFSearch, CombineMetaboliteAnnotationFiles, MetaboliteAnnotationFile
 from app.ws.mzML2ISA import ValidateMzML, Convert2ISAtab
@@ -224,6 +225,7 @@ def initialize_app(flask_app):
     api.add_resource(ExtractMSSpectra, res_path + "/ebi-internal/<string:study_id>/extract-peak-list")
     api.add_resource(ReindexStudy, res_path + "/ebi-internal/<string:study_id>/reindex")
     api.add_resource(ReindexAllPublicStudies, res_path + "/ebi-internal/studies/public/reindex-all")
+    api.add_resource(UnindexedStudy, res_path + "/ebi-internal/unindexed-studies")
     # api.add_resource(FileEncodingChecker, res_path + "/ebi-internal/studies/encoding-check")
     api.add_resource(Jira, res_path + "/ebi-internal/create_tickets")
 

--- a/scripts/create_study_tasks_table.sql
+++ b/scripts/create_study_tasks_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS study_tasks (
+    id serial PRIMARY KEY,
+    study_acc VARCHAR ( 255 ) NOT NULL,
+    task_name VARCHAR ( 255 ) NOT NULL,
+    last_request_time TIMESTAMP NOT NULL,
+    last_request_executed TIMESTAMP NOT NULL,
+    last_execution_time TIMESTAMP NOT NULL,
+    last_execution_status VARCHAR ( 255 ) NOT NULL,
+    last_execution_message text,
+    UNIQUE (study_acc, task_name)
+);


### PR DESCRIPTION
/metabolights/ws/ebi-internal/<study-id>/reindex task runs in thread pool now.

Moreover the following endpoint is added to check and get current unindexed or failed tasks
/ebi-internal/unindexed-studies

To activate this feature execute 'scripts/create_study_tasks_table.sql' on the target db.